### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ version working 100%.
 To play a live version: http://macek.github.com/google_pacman
 
 Or download the source and run it offline.
-
+[![Run on Repl.it](https://repl.it/badge/github/macek/google_pacman)](https://repl.it/github/macek/google_pacman)
 
 
 Sound in Offline Mode


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@enigma_dev/googlepacman).